### PR TITLE
删减重复代码，调整结构，增加新参数

### DIFF
--- a/nonebot_plugin_chatgpt_turbo/__init__.py
+++ b/nonebot_plugin_chatgpt_turbo/__init__.py
@@ -5,10 +5,11 @@ from nonebot import on_command
 from nonebot.params import CommandArg
 from nonebot.rule import to_me
 from nonebot.adapters.onebot.v11 import Message, MessageSegment
-from nonebot.adapters.onebot.v11 import GroupMessageEvent, PrivateMessageEvent
+from nonebot.adapters.onebot.v11 import GroupMessageEvent, PrivateMessageEvent, MessageEvent
 from .config import Config, ConfigError
 from .ChatSession import ChatSession
 
+# 配置导入
 plugin_config = Config.parse_obj(nonebot.get_driver().config.dict())
 
 if plugin_config.openai_http_proxy:
@@ -22,38 +23,91 @@ if not plugin_config.openai_api_key:
 api_key = plugin_config.openai_api_key
 model_id = plugin_config.openai_model_name
 max_limit = plugin_config.openai_max_history_limit
+public = plugin_config.chatgpt_turbo_public
 session = {}
 
 # 带上下文的聊天
-chat_request = on_command("chat", block=True, priority=1)
+chat_record = on_command("chat", block=False, priority=1)
+
+# 不带上下文的聊天
+chat_request = on_command("", rule=to_me(), block=False, priority=99)
+
+# 清除历史记录
+clear_request = on_command("clear", block=True, priority=1)
 
 
-@chat_request.handle()
-async def _(event: GroupMessageEvent, msg: Message = CommandArg()):
+# 带记忆的聊天
+@chat_record.handle()
+async def _(event: MessageEvent, msg: Message = CommandArg()):
+    # 若未开启私聊模式则检测到私聊就结束
+    if isinstance(event, PrivateMessageEvent) and not plugin_config.enable_private_chat:
+        chat_record.finish("对不起，私聊暂不支持此功能。")
+
+    # 检测是否填写 API key
     if api_key == "":
-        await chat_request.finish(MessageSegment.text("请先配置openai_api_key"), at_sender=True)
+        await chat_record.finish(MessageSegment.text("请先配置openai_api_key"), at_sender=True)
+
+    # 提取提问内容
+    content = msg.extract_plain_text()
+    if content == "" or content is None:
+        await chat_record.finish(MessageSegment.text("内容不能为空！"), at_sender=True)
+
+    await chat_record.send(MessageSegment.text("ChatGPT正在思考中......"))
+
+    # 创建会话ID
+    session_id = create_session_id(event)
+
+    # 初始化保存空间
+    if session_id not in session:
+        session[session_id] = ChatSession(api_key=api_key, model_id=model_id, max_limit=max_limit)
+
+    # 开始请求
+    try:
+        res = await session[session_id].get_response(content, proxy)
+
+    except Exception as error:
+        await chat_record.finish(str(error), at_sender=True)
+    await chat_record.finish(MessageSegment.text(res), at_sender=True)
+
+
+# 不带记忆的对话
+@chat_request.handle()
+async def _(event: MessageEvent, msg: Message = CommandArg()):
+
+    if isinstance(event, PrivateMessageEvent) and not plugin_config.enable_private_chat:
+        chat_record.finish("对不起，私聊暂不支持此功能。")
 
     content = msg.extract_plain_text()
     if content == "" or content is None:
-        await chat_request.finish(MessageSegment.text("内容不能为空！"), at_sender=True)
+        await chat_request.finish(MessageSegment.text("内容不能为空！"))
 
     await chat_request.send(MessageSegment.text("ChatGPT正在思考中......"))
 
-    if event.get_session_id() not in session:
-        session[event.get_session_id()] = ChatSession(api_key=api_key, model_id=model_id, max_limit=max_limit)
-
     try:
-        res = await session[event.get_session_id()].get_response(content, proxy)
+        res = await get_response(content, proxy)
 
     except Exception as error:
-        await chat_request.finish(str(error), at_sender=True)
-    await chat_request.finish(MessageSegment.text(res), at_sender=True)
+        await chat_request.finish(str(error))
+    await chat_request.finish(MessageSegment.text(res))
 
 
-# 不带上下文的聊天
-chat_request2 = on_command("", rule=to_me(), block=True, priority=99)
+@clear_request.handle()
+async def _(event: MessageEvent):
+    del session[create_session_id(event)]
+    await clear_request.finish(MessageSegment.text("成功清除历史记录！"), at_sender=True)
 
 
+# 根据消息类型创建会话id
+def create_session_id(event):
+    if isinstance(event, PrivateMessageEvent):
+        session_id = f"Private_{event.user_id}"
+    elif public:
+        session_id = event.get_session_id().replace(f"{event.user_id}", "Public")
+    else:
+        session_id = event.get_session_id()
+    return session_id
+
+# 发送请求模块
 async def get_response(content, proxy):
     openai.api_key = api_key
     if proxy != "":
@@ -72,83 +126,3 @@ async def get_response(content, proxy):
         res = res[1:]
 
     return res
-
-
-@chat_request2.handle()
-async def _(msg: Message = CommandArg()):
-    content = msg.extract_plain_text()
-    if content == "" or content is None:
-        await chat_request2.finish(MessageSegment.text("内容不能为空！"))
-
-    await chat_request2.send(MessageSegment.text("ChatGPT正在思考中......"))
-
-    try:
-        res = await get_response(content, proxy)
-
-    except Exception as error:
-        await chat_request2.finish(str(error))
-    await chat_request2.finish(MessageSegment.text(res))
-
-
-clear_request = on_command("clear", block=True, priority=1)
-
-
-@clear_request.handle()
-async def _(event: GroupMessageEvent):
-    del session[event.get_session_id()]
-    await clear_request.finish(MessageSegment.text("成功清除历史记录！"), at_sender=True)
-
-
-if plugin_config.enable_private_chat:
-    private_chat_request = on_command("chat", block=True, priority=1)
-
-
-    @private_chat_request.handle()
-    async def _(event: PrivateMessageEvent, msg: PrivateMessageEvent):
-        content = msg.extract_plain_text()
-        if content == "" or content is None:
-            await private_chat_request.finish(MessageSegment.text("内容不能为空！"), at_sender=True)
-
-        await private_chat_request.send(MessageSegment.text("ChatGPT正在思考中......"))
-
-        if event.get_user_id() not in session:
-            session[event.get_user_id()] = ChatSession(api_key=api_key, model_id=model_id, max_limit=max_limit)
-
-        try:
-            res = await session[event.get_user_id()].get_response(content, proxy)
-
-        except Exception as error:
-            await chat_request.finish(str(error), at_sender=True)
-        await private_chat_request.finish(MessageSegment.text(res), at_sender=True)
-
-
-    # 不带上下文的聊天
-    private_chat_request2 = on_command("", rule=to_me(), block=True, priority=99)
-
-
-    @private_chat_request2.handle()
-    async def _(msg: PrivateMessageEvent):
-        if api_key == "":
-            await private_chat_request2.finish(MessageSegment.text("请先配置openai_api_key"))
-
-        content = msg.extract_plain_text()
-        if content == "" or content is None:
-            await private_chat_request2.finish(MessageSegment.text("内容不能为空！"))
-
-        await private_chat_request2.send(MessageSegment.text("ChatGPT正在思考中......"))
-
-        try:
-            res = await get_response(content, proxy)
-
-        except Exception as error:
-            await private_chat_request2.finish(str(error))
-        await private_chat_request2.finish(MessageSegment.text(res))
-
-
-    private_clear_request = on_command("/clear", block=True, priority=1)
-
-
-    @private_clear_request.handle()
-    async def _(event: PrivateMessageEvent):
-        del session[event.get_user_id()]
-        await private_clear_request.finish(MessageSegment.text("成功清除历史记录！"), at_sender=True)

--- a/nonebot_plugin_chatgpt_turbo/config.py
+++ b/nonebot_plugin_chatgpt_turbo/config.py
@@ -8,6 +8,7 @@ class Config(BaseModel, extra=Extra.ignore):
     openai_max_history_limit: Optional[int] = 5
     openai_http_proxy: Optional[str] = None
     enable_private_chat: bool = True
+    chatgpt_turbo_public: bool = False  # 群聊是否开启公共会话
 
 
 class ConfigError(Exception):


### PR DESCRIPTION
将判断私聊消息挪进函数内，删除重复性高的代码
为生成session_id新建了函数，可同时兼容私聊与群聊
在上述基础上新增一项参数 chatgpt_turbo_public，此配置项可以控制群聊内是独立对话或公开对话（公开对话即每个人都在同一段对话中）

**注意**：学校宿舍快断电了我还没有进行测试，但是编辑器显示没有语法错误，你可以先测试一下没问题再merge
*推荐你再开一个dev分支用来测试*